### PR TITLE
chore: Fix GITHUB_TOKEN for goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -23,4 +23,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.gh-app-auth.outputs.token }}


### PR DESCRIPTION
goreleaser用のGITHUB_TOKENをgithub appsのものに書き換えます。
cc @achiku @summerwind @hiroakis 