### PR TITLE
fix: Update goreleaser args from deprecated --rm-dist to --clean

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.gh-app-auth.outputs.token }}


### PR DESCRIPTION
goreleaser doesn't work on GitHub actions. This PR replaces `--rm-dist` with `--clean`.

https://github.com/kanmu/dgw/actions/runs/17259101203/job/48976534796
```
Run goreleaser/goreleaser-action@v2
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.11.2/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/573f972b-a362-431f-bc82-a1296eebb981 -f /home/runner/work/_temp/580bd028-d5cf-4669-a5a2-2694bcdb2536
GoReleaser latest installed successfully
v1.2.2 tag found for commit 'bb8de01'
/opt/hostedtoolcache/goreleaser-action/2.11.2/x64/goreleaser release --rm-dist
unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.11.2/x64/goreleaser' failed with exit code 1
```