### PR TITLE
fix: add version field to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
Add `version: 2` to specify the configuration format version, ensuring compatibility with newer GoReleaser versions.