### PR TITLE
fix: replace deprecated 'tap' with 'repository' in Homebrew config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
 checksum:
   name_template: "checksums.txt"
 brews:
-  - tap:
+  - repository:
       owner: kanmu
       name: homebrew-tools
     homepage: https://github.com/kanmu/dgw


### PR DESCRIPTION
GoReleaser v2 no longer supports the 'tap' field under 'brews'. Replaced it with 'repository' to fix configuration errors.

The check has been passed.

```
dgw = goreleaser check
  • checking                                  path=.goreleaser.yml
  • brews is being phased out in favor of homebrew_casks, check https://goreleaser.com/deprecations#brews for more info
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```
